### PR TITLE
Update tests to upload a small & large file

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,13 +1,13 @@
 {
-  "originHash" : "b935a506928459b6970f5d55284a9d5a71b4209a752017c9524b72ff7ab7e1bc",
+  "originHash" : "1caa6f85102d92e5a548d682dacc4835129b069fce41a7c9c0b74639e521f7ac",
   "pins" : [
     {
       "identity" : "aws-crt-swift",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/awslabs/aws-crt-swift",
       "state" : {
-        "revision" : "5a65eb60edbd080a8a79af813a5bb6e5ff387550",
-        "version" : "0.43.0"
+        "revision" : "5be6550f81c760cceb0a43c30d4149ac55c5640c",
+        "version" : "0.52.1"
       }
     },
     {
@@ -15,8 +15,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/awslabs/aws-sdk-swift",
       "state" : {
-        "revision" : "f9c89cbe00814c5939dafef58e6637e2ce7d7f3d",
-        "version" : "1.1.0"
+        "revision" : "49090d3a9e308df5643891cbc68fcbeb6170a4d4",
+        "version" : "1.3.18"
       }
     },
     {
@@ -24,8 +24,17 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/smithy-lang/smithy-swift",
       "state" : {
-        "revision" : "c1adba401d08e511a63cf6270773ed17c92f2032",
-        "version" : "0.110.0"
+        "revision" : "aa4cb4585232b52f116286e432dca055df698863",
+        "version" : "0.131.0"
+      }
+    },
+    {
+      "identity" : "swift-argument-parser",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-argument-parser.git",
+      "state" : {
+        "revision" : "41982a3656a71c768319979febd796c6fd111d5c",
+        "version" : "1.5.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -21,7 +21,7 @@ let package = Package(
         // Dependencies declare other packages that this package depends on.
         .package(
             url: "https://github.com/awslabs/aws-sdk-swift",
-            from: "1.0.0"
+            exact: "1.3.18"
         )
     ],
     targets: [


### PR DESCRIPTION
This PR updates `CellsSDKTests.testUpload()` to upload a small and large file so we can test behaviour with and without aws chunked encoding - only the large file will be chunked.

Specifically it:

- Updates the AWS sdk to match that being using in the Wire client.
- Updates `CellsSDKTests.testUpload()` that it tests two file uploads - small & large - as a `stream` type - previously it was uploading a file as a `file` type.
- Adds some annoying code to only configure SDKLoggingSystem once per process otherwise we hit a precondidion.